### PR TITLE
kipfw: fix Linux kernel version detection

### DIFF
--- a/kipfw/Makefile
+++ b/kipfw/Makefile
@@ -223,7 +223,7 @@ ifeq ($(LIN_VER),openwrt)	#--- { The Makefile section for openwrt ---
 endif # ---- } end openwrt version
 
 
-ifneq ($(shell echo $(LIN_VER)|grep '2.4'),)	#--- {
+ifneq ($(shell echo $(LIN_VER)|grep '^204'),)	#--- {
   # Makefile section for the linux 2.4 version
   # tested on linux-2.4.35.4, does not work with 2.4.37
   #


### PR DESCRIPTION
Current version detection scheme doesn't work properly with
all Linux version numbers. For example, grep '2.4' will return
non-zero string for version number 30244 (Linux 3.2.68):

$ echo 30244 | grep '2.4'
30244

It will lead to execution of Makefile section for the linux 2.4 version.

This patch fixes the regular expression used by grep in Makefile, so
only 3 first digits of Linux version numbers are matched to the pattern.

Signed-off-by: Anton Tikhomirov anton.tikhomirov@cdnetworks.co.kr
