### PR TITLE
Add support for kernel > v4.0.

### DIFF
--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -478,10 +478,19 @@ call_ipfw(
 #else
 	struct sk_buff  *skb,
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	const struct net_device *in, const struct net_device *out,
 	int (*okfn)(struct sk_buff *))
+#else
+	const struct nf_hook_state *state)
+#endif
 {
-	(void)hooknum; (void)skb; (void)in; (void)out; (void)okfn; /* UNUSED */
+	(void)hooknum; (void)skb; /* UNUSED */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+	(void)in; (void)out; (void)okfn; /* UNUSED */
+#else
+	(void)state; /* UNUSED */
+#endif
 	return NF_QUEUE;
 }
 


### PR DESCRIPTION
In change 1d1de89b, nf_queue_entry was refactored, and since v4.0-rc6
some of its member variables have now been extracted to nf_hook_state.
