### PR TITLE
linux version

### DIFF
--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -467,7 +467,7 @@ static struct nf_sockopt_ops ipfw_sockopts = {
  */
 static unsigned int
 call_ipfw(
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,32,0)
 	unsigned int hooknum,
 #else
 	const struct nf_hook_ops *hooknum,

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -467,7 +467,7 @@ static struct nf_sockopt_ops ipfw_sockopts = {
  */
 static unsigned int
 call_ipfw(
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,32,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
 	unsigned int hooknum,
 #else
 	const struct nf_hook_ops *hooknum,
@@ -478,7 +478,7 @@ call_ipfw(
 #else
 	struct sk_buff  *skb,
 #endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,32,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	const struct net_device *in, const struct net_device *out,
 	int (*okfn)(struct sk_buff *))
 #else
@@ -486,7 +486,7 @@ call_ipfw(
 #endif
 {
 	(void)hooknum; (void)skb; /* UNUSED */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,32,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	(void)in; (void)out; (void)okfn; /* UNUSED */
 #else
 	(void)state; /* UNUSED */

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -478,7 +478,7 @@ call_ipfw(
 #else
 	struct sk_buff  *skb,
 #endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,32,0)
 	const struct net_device *in, const struct net_device *out,
 	int (*okfn)(struct sk_buff *))
 #else
@@ -486,7 +486,7 @@ call_ipfw(
 #endif
 {
 	(void)hooknum; (void)skb; /* UNUSED */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,32,0)
 	(void)in; (void)out; (void)okfn; /* UNUSED */
 #else
 	(void)state; /* UNUSED */

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -478,7 +478,7 @@ call_ipfw(
 #else
 	struct sk_buff  *skb,
 #endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
 	const struct net_device *in, const struct net_device *out,
 	int (*okfn)(struct sk_buff *))
 #else
@@ -486,7 +486,7 @@ call_ipfw(
 #endif
 {
 	(void)hooknum; (void)skb; /* UNUSED */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
 	(void)in; (void)out; (void)okfn; /* UNUSED */
 #else
 	(void)state; /* UNUSED */

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -467,23 +467,10 @@ static struct nf_sockopt_ops ipfw_sockopts = {
  */
 static unsigned int
 call_ipfw(
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
-	unsigned int hooknum,
-#else
 	const struct nf_hook_ops *hooknum,
-#endif
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,23) // in 2.6.22 we have **
-	struct sk_buff  **skb,
-#else
 	struct sk_buff  *skb,
-#endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	const struct net_device *in, const struct net_device *out,
-	int (*okfn)(struct sk_buff *))
-#else
 	const struct nf_hook_state *state)
-#endif
 {
 	(void)hooknum; (void)skb; /* UNUSED */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -472,12 +472,6 @@ call_ipfw(
 	const struct net_device *in, const struct net_device *out,
 	const struct nf_hook_state *state)
 {
-	(void)hooknum; (void)skb; /* UNUSED */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
-	(void)in; (void)out; (void)okfn; /* UNUSED */
-#else
-	(void)state; /* UNUSED */
-#endif
 	return NF_QUEUE;
 }
 

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -565,7 +565,7 @@ ipfw2_queue_handler(QH_ARGS)
 	m->m_skb = skb;
 	m->m_len = skb->len;		/* len from ip header to end */
 	m->m_pkthdr.len = skb->len;	/* total packet len */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32)
 	m->m_pkthdr.rcvif = info->indev;
 #else
 	m->m_pkthdr.rcvif = info->state.in;
@@ -578,7 +578,7 @@ ipfw2_queue_handler(QH_ARGS)
 #endif
 
 	/* XXX add the interface */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32)
 	if (info->hook == IPFW_HOOK_IN) {
 		ret = ipfw_check_hook(NULL, &m, info->indev, PFIL_IN, NULL);
 	} else {

--- a/kipfw/ipfw2_mod.c
+++ b/kipfw/ipfw2_mod.c
@@ -478,10 +478,19 @@ call_ipfw(
 #else
 	struct sk_buff  *skb,
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	const struct net_device *in, const struct net_device *out,
 	int (*okfn)(struct sk_buff *))
+#else
+	const struct nf_hook_state *state)
+#endif
 {
-	(void)hooknum; (void)skb; (void)in; (void)out; (void)okfn; /* UNUSED */
+	(void)hooknum; (void)skb; /* UNUSED */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+	(void)in; (void)out; (void)okfn; /* UNUSED */
+#else
+	(void)state; /* UNUSED */
+#endif
 	return NF_QUEUE;
 }
 
@@ -556,7 +565,11 @@ ipfw2_queue_handler(QH_ARGS)
 	m->m_skb = skb;
 	m->m_len = skb->len;		/* len from ip header to end */
 	m->m_pkthdr.len = skb->len;	/* total packet len */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	m->m_pkthdr.rcvif = info->indev;
+#else
+	m->m_pkthdr.rcvif = info->state.in;
+#endif
 	m->queue_entry = info;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)	/* XXX was 2.6.0 */
 	m->m_data = (char *)skb->nh.iph;
@@ -565,11 +578,19 @@ ipfw2_queue_handler(QH_ARGS)
 #endif
 
 	/* XXX add the interface */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 	if (info->hook == IPFW_HOOK_IN) {
 		ret = ipfw_check_hook(NULL, &m, info->indev, PFIL_IN, NULL);
 	} else {
 		ret = ipfw_check_hook(NULL, &m, info->outdev, PFIL_OUT, NULL);
 	}
+#else
+	if (info->state.hook == IPFW_HOOK_IN) {
+		ret = ipfw_check_hook(NULL, &m, info->state.in, PFIL_IN, NULL);
+	} else {
+		ret = ipfw_check_hook(NULL, &m, info->state.out, PFIL_OUT, NULL);
+	}
+#endif
 
 	if (m != NULL) {	/* Accept. reinject and free the mbuf */
 		REINJECT(info, NF_ACCEPT);


### PR DESCRIPTION
there are somer issues in high linux-kernel version,always caused by kipfw/ipfw2_mod.c
and lots of linux version are added as if,else condition.I dont think there is a good solution,as some data structure always changed  by kernel.take following example
static struct nf_hook_ops ipfw_ops[] __read_mostly = {
        {
                .hook           = call_ipfw,
                .pf             = PF_INET,
                .hooknum        = IPFW_HOOK_IN,
                .priority       = NF_IP_PRI_FILTER,
                SET_MOD_OWNER
        },
hook struct is not same at specific linux version.so some users will get errors.
check hook struct defin in this file /usr/src/kernels/linux-xxx/include/linux/netfilter.h
and then fix it.
